### PR TITLE
Png endpoints

### DIFF
--- a/api/requesParser.test.js
+++ b/api/requesParser.test.js
@@ -49,3 +49,18 @@ describe('Parses requests correctly', () => {
       });
   });
 });
+
+test('memenames ending in .png and not are equal', async (done) => {
+  const mock_request__yes_png = {
+    params : {memeName: 'test-meme.png'},
+    query: {t1: 'celery'},
+  };
+  const mock_request__no_png = {
+    params : {memeName: 'test-meme'},
+    query: {t1: 'celery'},
+  };
+  const result__yes_png = await requestParser(mock_request__yes_png);
+  const result__no_png = await requestParser(mock_request__no_png);
+  expect(result__yes_png).toEqual(result__no_png);
+  done();
+});

--- a/api/requestParser.js
+++ b/api/requestParser.js
@@ -2,10 +2,12 @@
  * This bit parses a request and ;returns a memetemplate
  */
 
+const {stripPNG} = require('../randomHelpers');
 const fs = require('fs');
 
 module.exports = async function (req) {
-  const fileName = `${req.params.memeName}.json`;
+  const memeName = stripPNG(req.params.memeName);
+  const fileName = `${memeName}.json`;
   const json = await fs.promises.readFile(`instant-meme/templates/${fileName}`, 'utf-8');
   let obj = JSON.parse(json);
   

--- a/commonHandlers.js
+++ b/commonHandlers.js
@@ -1,0 +1,10 @@
+const commonHandlers = {
+  e405: function(_req, res, _next) {
+    res.status(405).send('This Api only accepts GET requests.');
+  },
+  e404: function (_req, res, _next) {
+    res.status(404).send('File Not Found');
+  }
+};
+
+module.exports = commonHandlers;

--- a/commonHandlers.test.js
+++ b/commonHandlers.test.js
@@ -1,0 +1,18 @@
+const commonHandlers = require('./commonHandlers');
+const {mwsupertest} = require('middleware-supertest');
+const { test, describe, expect } = require('@jest/globals');
+const supertest = require('supertest');
+const { get } = require('.');
+
+test('e404', async (done) => {
+  await mwsupertest(commonHandlers.e404)
+    .get('/')
+    .expect(404);
+  done();
+});
+test('e405', async (done) => {
+  await mwsupertest(commonHandlers.e405)
+    .get('/')
+    .expect(405);
+  done();
+});

--- a/index.js
+++ b/index.js
@@ -3,14 +3,7 @@ const router = express.Router();
 const requestParser = require('./api/requestParser');
 const memeBuilder = require('./api/memebuilder');
 
-const commonHandlers = {
-  e405: function(_req, res, _next) {
-    res.status(405).send('This Api only accepts GET requests.');
-  },
-  e404: function (_req, res, _next) {
-    res.status(404).send('File Not Found');
-  }
-};
+const commonHandlers =  require('./commonHandlers');
 
 async function memeHandler(req, res, _next) {
   const memeName = req.params['memeName'];

--- a/randomHelpers.js
+++ b/randomHelpers.js
@@ -1,0 +1,14 @@
+/**
+ * Random helper functions so I can export and test them easily.
+ */
+
+ /**
+ * 
+ * @param {String} str String suspected of ending in .png
+ * @returns {String} String that deffinantly does not end in .png
+ */
+exports.stripPNG = function (str=""){
+  if(!str) return '';
+  if(typeof str !== 'string') str =  str.toString()
+  return (str.slice(-4) === '.png' ? str.slice(0, -4) : str);
+}

--- a/randomHelpers.test.js
+++ b/randomHelpers.test.js
@@ -1,0 +1,27 @@
+const {
+  stripPNG,
+} = require('./randomHelpers');
+
+describe('stripPNG(str)', () => {
+  const strings = [
+    'brain.png',
+    '.png',
+    'bellringer',
+    'tobor.png.gop',
+    'tollbooth.png',
+  ];
+  strings.forEach(str => {
+    test(str, () => {
+      const result = /.png$/.test(stripPNG(str));
+      expect(result).toEqual(false);
+    });
+  });
+  test('null', () => {
+    const result = /.png$/.test(stripPNG(null));
+    expect(result).toEqual(false);
+  });
+  test('22', () => {
+    const result = /.png$/.test(stripPNG(22));
+    expect(result).toEqual(false);
+  });
+});


### PR DESCRIPTION
Some chat programs ignore files not ending in a .img filetag.
This change allowed memenames to optionally have the .png filetag appended to them to fix this.